### PR TITLE
Unnecessary `codespell` setting and `validate-pyproject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,26 @@ If invoking `flake8` as part of `pre-commit`,
 run this only in CI because this check isn't relevant for most commits.
 
 </td></tr>
+<tr><td>
+
+[`validate-pyproject`](https://github.com/abravalheri/validate-pyproject)
+
+</td><td>Yes</td><td>
+
+Validating `pyproject.toml` configuration(s)
+
+</td><td>
+
+`pre-commit` hook
+
+</td><td>
+
+By specifying
+[`validate-pyproject-schema-store`](https://github.com/henryiii/validate-pyproject-schema-store)
+in `additional_dependencies`,
+configurations for `mypy`, `ruff`, `uv`, etc. will also be validated.
+
+</td></tr>
 </table>
 
 ## Git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ preview = true
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# SEE: https://github.com/codespell-project/codespell/issues/1212#issuecomment-1744768533
-ignore-regex = ".{1024}|.*codespell-ignore.*"
 ignore-words-list = "astroid,ser"
 
 [tool.coverage]


### PR DESCRIPTION
- Removed `codespell`'s `ignore-regex` settings as `2.3.0` incorporated it
- Documented `validate-pyproject` hook in `README.md`