### PR TITLE
 Moved from `markdownlint-cli` to `pymarkdown`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,11 +82,10 @@ repos:
     rev: 0.0.10
     hooks:
       - id: markdown-toc-creator
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+  - repo: https://github.com/jackdewinter/pymarkdown
+    rev: v0.9.31
     hooks:
-      - id: markdownlint
-        args: [--config=pyproject.toml, --configPointer=/tool/markdownlint]
+      - id: pymarkdown
   - repo: https://github.com/sqlfluff/sqlfluff
     rev: 3.4.2
     hooks:

--- a/README.md
+++ b/README.md
@@ -236,11 +236,34 @@ Markdown table of contents
 </td><td></td></tr>
 <tr><td>
 
-[`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli)
+[`pymarkdown`](https://github.com/jackdewinter/pymarkdown)
+([docs](https://pymarkdown.readthedocs.io/en/stable/))
 
 </td><td>
 
 Yes
+
+</td><td>
+
+Lint Markdown files
+
+</td><td>
+
+`pre-commit` hook
+
+</td><td>
+
+This tool is a superset of the below `markdownlint-cli`,
+and on the same repos was seen to catch more errors.
+
+</td></tr>
+<tr><td>
+
+[`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli)
+
+</td><td>
+
+No
 
 </td><td>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # configurator
 
+<!-- pyml disable-num-lines 6 line-length -->
+
 [![github](https://img.shields.io/badge/GitHub-%23121011.svg?logo=github&logoColor=white)](https://github.com/jamesbraza/configurator)
 ![ci](https://github.com/jamesbraza/configurator/actions/workflows/lint-test.yaml/badge.svg)
 [![repo status](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
@@ -974,7 +976,7 @@ but `nitpick` itself lacked the configurability for adoption here.
 
 ### Changing Repos
 
-<!-- markdownlint-disable line-length -->
+<!-- pyml disable line-length -->
 
 ```shell
 pathver() {
@@ -1034,15 +1036,17 @@ a() {
 }
 ```
 
+<!-- pyml enable line-length -->
+
 This was taken from
 <https://github.com/biobuddies/helicopyter/blob/main/.biobuddies/includes.bash>.
 
 ### `.gitignore` Creation
+
+<!-- pyml disable-num-lines 3 line-length -->
 
 ```bash
 curl -s \
   https://raw.githubusercontent.com/github/gitignore/master/{Global/Vim,Global/JetBrains,Global/VisualStudioCode,Global/macOS,Python}.gitignore \
   > .gitignore
 ```
-
-<!-- markdownlint-enable line-length -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ max-line-length = 97  # Match ruff line-length
 style = "google"
 
 [tool.markdownlint]
-no-duplicate-heading = false  # GitHub appends -X for duplicated headings
+no-duplicate-heading = {siblings_only = true}  # GitHub appends -X for duplicated headings
 no-inline-html = false
 
 [tool.markdownlint.line-length]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,16 +109,6 @@ ignore = [
 max-line-length = 97  # Match ruff line-length
 style = "google"
 
-[tool.markdownlint]
-no-duplicate-heading = {siblings_only = true}  # GitHub appends -X for duplicated headings
-no-inline-html = false
-
-[tool.markdownlint.line-length]
-code_block_line_length = 88  # Match ruff line-length
-line_length = 120  # Match ruff max-doc-length
-stern = true
-tables = false
-
 [tool.mypy]
 # Type-checks the interior of functions without type annotations.
 check_untyped_defs = true
@@ -298,6 +288,16 @@ score = false
 [tool.pylint.similarities]
 # Minimum lines number of a similarity.
 min-similarity-lines = 10
+
+[tool.pymarkdown]
+plugins.line-length.code_block_line_length = 88  # Match ruff line-length
+plugins.line-length.enabled = true
+plugins.line-length.line_length = 120  # Match ruff max-doc-length
+plugins.line-length.stern = true
+plugins.line-length.tables = false
+plugins.no-duplicate-heading.siblings_only = true  # GitHub appends -X for duplicated headings
+plugins.no-emphasis-as-heading.enabled = false
+plugins.no-inline-html.enabled = false
 
 [tool.pytest.ini_options]
 # Add the specified `OPTS` to the set of command line arguments as if they had


### PR DESCRIPTION
PyMarkdown has three main advantages:
- It catches more errors when run on the same repo
- More configurable disable pragmas
- Cleaner `pyproject.toml` and `pre-commit` integrations