### PR TITLE
Support for Python 3.14

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11, 3.13] # Our min and max supported Python versions
+        python-version: [3.11, 3.14] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: toml-sort-fix
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+    rev: v1.7.8
     hooks:
       - id: docformatter
         additional_dependencies: [".[tomli]"]

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ I am a fan of the
 
 </td><td>
 
-Yes,`>=1.7`
+Yes, `>=1.7.8`
 
 </td><td>
 
@@ -414,7 +414,12 @@ Formatting docstrings
 
 `pre-commit` hook
 
-</td><td></td></tr>
+</td><td>
+
+Lower pin for Python 3.14 support from its
+[PR#325](https://github.com/PyCQA/docformatter/pull/325).
+
+</td></tr>
 <tr><td>
 
 [`nb-clean`](https://github.com/srstevenson/nb-clean)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python",
     "Topic :: Software Development",
 ]


### PR DESCRIPTION
Mainly pulling in https://github.com/PyCQA/docformatter/pull/325, released in https://github.com/PyCQA/docformatter/pull/342.